### PR TITLE
chore: adopt standardization baseline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,51 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Markdown files
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false
+
+# YAML files
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_style = space
+indent_size = 2
+
+# JavaScript/TypeScript
+[*.{js,jsx,ts,tsx}]
+indent_style = space
+indent_size = 2
+
+# Python
+[*.py]
+indent_style = space
+indent_size = 4
+max_line_length = 120
+
+# Shell scripts
+[*.sh]
+indent_style = space
+indent_size = 2
+
+# Makefiles
+[Makefile]
+indent_style = tab
+
+# Package files
+[{package.json,*.lock}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Automated by bamr87 standardize-fanout (tools/fanout.sh): seeds the baseline artifacts (editorconfig,agent-context). Additive-only — nothing the repo already has is overwritten. See bamr87/bamr87 docs/STANDARDS.md.