### PR TITLE
style(markdown): enforce one paragraph per line

### DIFF
--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -191,10 +191,7 @@ Continue with clear, actionable steps...
 Provide simple, working examples that readers can follow:
 
 ```javascript
-// Path: basic-implementation
-const example = new ExampleClass();
-const result = example.performAction();
-console.log('Result:', result);
+// Path: basic-implementation const example = new ExampleClass(); const result = example.performAction(); console.log('Result:', result);
 ```
 
 ### Advanced Example
@@ -202,8 +199,7 @@ console.log('Result:', result);
 More complex scenarios for experienced users:
 
 ```javascript
-// Path: advanced-implementation-with-error-handling
-class AdvancedExample {
+// Path: advanced-implementation-with-error-handling class AdvancedExample {
     async performComplexAction() {
         try {
             const result = await this.complexOperation();
@@ -1223,9 +1219,7 @@ Brief description of the MCP server's purpose and capabilities.
 
 ### Container Configuration
 ```yaml
-version: '3.8'
-services:
-  mcp-server:
+version: '3.8' services: mcp-server:
     build: ./mcp-servers/[server-name]
     environment:
       - MCP_SERVER_NAME=[server-name]
@@ -1274,17 +1268,14 @@ async def list_resources():
 ### Tool Examples
 
 ```typescript
-// TypeScript client example
-const client = new PathAwareMCPClient("docker", ["exec", "-i", "mcp-[server-name]"]);
-await client.connect();
+// TypeScript client example const client = new PathAwareMCPClient("docker", ["exec", "-i", "mcp-[server-name]"]); await client.connect();
 
 const result = await client.callTool("[tool_name]", {
     param1: "example_value",
     param2: 42
 });
 
-console.log("Tool result:", result);
-await client.disconnect();
+console.log("Tool result:", result); await client.disconnect();
 ```
 
 ## Prompt Templates
@@ -1349,8 +1340,7 @@ docker-compose -f docker-compose.mcp.yml restart mcp-[server-name]
 ### Local Development Setup
 ```bash
 # Clone repository
-git clone [repository-url]
-cd [repository-name]
+git clone [repository-url] cd [repository-name]
 
 # Start development environment
 docker-compose -f docker-compose.mcp.yml up -d mcp-[server-name]
@@ -1430,8 +1420,7 @@ This guide provides comprehensive information about integrating Model Context Pr
 ### Installation
 ```bash
 # Clone the MCP-enabled repository
-git clone [repository-url]
-cd [repository-name]
+git clone [repository-url] cd [repository-name]
 
 # Start MCP server infrastructure
 docker-compose -f docker-compose.mcp.yml up -d
@@ -1445,16 +1434,13 @@ docker-compose -f docker-compose.mcp.yml up -d
 from src.mcp.clients.mcp_client import PathAwareMCPClient
 
 # Connect to filesystem MCP server
-client = PathAwareMCPClient("docker", ["exec", "-i", "mcp-filesystem"])
-await client.connect()
+client = PathAwareMCPClient("docker", ["exec", "-i", "mcp-filesystem"]) await client.connect()
 
 # List available resources
-resources = await client.listResources()
-print(f"Found {len(resources)} resources")
+resources = await client.listResources() print(f"Found {len(resources)} resources")
 
 # Read a specific file
-content = await client.readResource("file://src/main.py")
-print("File content:", content[:100], "...")
+content = await client.readResource("file://src/main.py") print("File content:", content[:100], "...")
 
 await client.disconnect()
 ```
@@ -1556,8 +1542,7 @@ cat config/mcp/validation_report.json | jq '.summary'
 ### Logging
 MCP operations are logged with path context:
 ```
-[2025-07-19 10:30:15] [INFO] [mcp_client] [resource_reading] Reading resource: file://src/main.py
-[2025-07-19 10:30:15] [INFO] [mcp_client] [tool_execution_list_directory] Executing tool: list_directory
+[2025-07-19 10:30:15] [INFO] [mcp_client] [resource_reading] Reading resource: file://src/main.py [2025-07-19 10:30:15] [INFO] [mcp_client] [tool_execution_list_directory] Executing tool: list_directory
 ```
 
 ## Best Practices

--- a/.github/instructions/markdown.instructions.md
+++ b/.github/instructions/markdown.instructions.md
@@ -423,18 +423,12 @@ def factorial(n):
 
 # Show command-line examples with prompts
 ```bash
-$ npm install
-$ npm run build
-$ npm test
+$ npm install $ npm run build $ npm test
 ```
 
 # Include expected output when helpful
 ```console
-$ ls -la
-total 24
-drwxr-xr-x  6 user staff  192 Jul 19 10:30 .
-drwxr-xr-x  3 user staff   96 Jul 19 10:29 ..
--rw-r--r--  1 user staff  123 Jul 19 10:30 README.md
+$ ls -la total 24 drwxr-xr-x  6 user staff  192 Jul 19 10:30 . drwxr-xr-x  3 user staff   96 Jul 19 10:29 .. -rw-r--r--  1 user staff  123 Jul 19 10:30 README.md
 ```
 
 # Use diff format for showing changes
@@ -729,24 +723,12 @@ classDiagram
 ```markdown
 # Simple diagrams using ASCII art
 ```
-┌─────────────┐    ┌─────────────┐    ┌─────────────┐
-│   Client    │───▶│   Server    │───▶│  Database   │
-│             │    │             │    │             │
-└─────────────┘    └─────────────┘    └─────────────┘
+┌─────────────┐    ┌─────────────┐    ┌─────────────┐ │   Client    │───▶│   Server    │───▶│  Database   │ │             │    │             │    │             │ └─────────────┘    └─────────────┘    └─────────────┘
 ```
 
 # File structure representation
 ```
-project/
-├── src/
-│   ├── components/
-│   │   ├── Header.js
-│   │   └── Footer.js
-│   └── utils/
-│       └── helpers.js
-├── tests/
-│   └── unit/
-└── docs/
+project/ ├── src/ │   ├── components/ │   │   ├── Header.js │   │   └── Footer.js │   └── utils/ │       └── helpers.js ├── tests/ │   └── unit/ └── docs/
     └── README.md
 ```
 ```
@@ -898,37 +880,22 @@ Creates a new user account.
 ### Request Example
 
 ```json
-{
-  "name": "John Doe",
-  "email": "john@example.com",
-  "password": "securePassword123",
-  "role": "admin"
-}
+{ "name": "John Doe", "email": "john@example.com", "password": "securePassword123", "role": "admin" }
 ```
 
 ### Response Examples
 
 #### Success (201 Created)
 ```json
-{
-  "id": "user_123",
-  "name": "John Doe",
-  "email": "john@example.com",
-  "role": "admin",
-  "createdAt": "2025-07-19T10:30:00Z"
-}
+{ "id": "user_123", "name": "John Doe", "email": "john@example.com", "role": "admin", "createdAt": "2025-07-19T10:30:00Z" }
 ```
 
 #### Error (400 Bad Request)
 ```json
-{
-  "error": "validation_failed",
-  "message": "Invalid email format",
-  "details": {
+{ "error": "validation_failed", "message": "Invalid email format", "details": {
     "field": "email",
     "code": "INVALID_FORMAT"
-  }
-}
+} }
 ```
 
 ### cURL Examples
@@ -962,10 +929,7 @@ Calculates the Euclidean distance between two points.
 ### Example
 
 ```javascript
-const pointA = { x: 0, y: 0 };
-const pointB = { x: 3, y: 4 };
-const distance = calculateDistance(pointA, pointB);
-console.log(distance); // Output: 5
+const pointA = { x: 0, y: 0 }; const pointB = { x: 3, y: 4 }; const distance = calculateDistance(pointA, pointB); console.log(distance); // Output: 5
 ```
 
 ### Notes
@@ -1070,22 +1034,13 @@ Write content for humans first, search engines second:
 ```html
 <!-- JSON-LD structured data -->
 <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "TechArticle",
-  "headline": "Markdown Documentation Best Practices",
-  "author": {
+{ "@context": "https://schema.org", "@type": "TechArticle", "headline": "Markdown Documentation Best Practices", "author": {
     "@type": "Person",
     "name": "AI-Seed Team"
-  },
-  "datePublished": "2025-07-19",
-  "dateModified": "2025-07-19",
-  "description": "Comprehensive guide to writing technical documentation in Markdown",
-  "mainEntityOfPage": {
+}, "datePublished": "2025-07-19", "dateModified": "2025-07-19", "description": "Comprehensive guide to writing technical documentation in Markdown", "mainEntityOfPage": {
     "@type": "WebPage",
     "@id": "https://example.com/markdown-guide"
-  }
-}
+} }
 </script>
 ```
 
@@ -1168,12 +1123,7 @@ Starting a new major topic.
 #### Jekyll Configuration
 ```yaml
 # _config.yml
-markdown: kramdown
-highlighter: rouge
-kramdown:
-  input: GFM
-  syntax_highlighter: rouge
-  syntax_highlighter_opts:
+markdown: kramdown highlighter: rouge kramdown: input: GFM syntax_highlighter: rouge syntax_highlighter_opts:
     block:
       line_numbers: true
 
@@ -1187,10 +1137,7 @@ plugins:
 #### MkDocs Configuration
 ```yaml
 # mkdocs.yml
-site_name: Documentation
-theme:
-  name: material
-  features:
+site_name: Documentation theme: name: material features:
     - navigation.sections
     - navigation.top
     - search.highlight
@@ -1249,12 +1196,7 @@ plugins:
 ```
 
 ```javascript
-// docusaurus.config.js
-module.exports = {
-  title: 'Documentation',
-  tagline: 'Comprehensive project documentation',
-  url: 'https://docs.example.com',
-  baseUrl: '/',
+// docusaurus.config.js module.exports = { title: 'Documentation', tagline: 'Comprehensive project documentation', url: 'https://docs.example.com', baseUrl: '/',
   
   presets: [
     [
@@ -1290,8 +1232,7 @@ module.exports = {
         },
       ],
     },
-  },
-};
+}, };
 ```
 
 ### Automated Quality Checks
@@ -1299,16 +1240,7 @@ module.exports = {
 #### Markdown Linting Configuration
 ```yaml
 # .markdownlint.yml
-default: true
-line-length:
-  line_length: 100
-  code_blocks: false
-  tables: false
-  headings: false
-no-duplicate-heading:
-  siblings_only: true
-no-inline-html:
-  allowed_elements:
+default: true line-length: line_length: 100 code_blocks: false tables: false headings: false no-duplicate-heading: siblings_only: true no-inline-html: allowed_elements:
     - 'br'
     - 'sub'
     - 'sup'
@@ -1319,15 +1251,12 @@ no-inline-html:
 #### Vale Style Guide
 ```yaml
 # .vale.ini
-StylesPath: styles
-MinAlertLevel: suggestion
+StylesPath: styles MinAlertLevel: suggestion
 
-[*.md]:
-  BasedOnStyles:
+[*.md]: BasedOnStyles:
     - Vale
     - Microsoft
-  Microsoft.Contractions: NO
-  Vale.Spelling: YES
+Microsoft.Contractions: NO Vale.Spelling: YES
 ```
 
 #### GitHub Actions Workflow
@@ -1335,14 +1264,12 @@ MinAlertLevel: suggestion
 # .github/workflows/docs-quality.yml
 name: Documentation Quality Check
 
-on:
-  pull_request:
+on: pull_request:
     paths:
       - 'docs/**'
       - '*.md'
 
-jobs:
-  markdown-lint:
+jobs: markdown-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -1419,15 +1346,7 @@ jobs:
 #### Asset Organization
 ```markdown
 # Efficient asset structure
-assets/
-├── images/
-│   ├── optimized/          # Compressed versions
-│   ├── originals/          # Source files (not served)
-│   └── thumbnails/         # Small preview images
-├── videos/
-│   ├── compressed/         # Web-optimized videos
-│   └── captions/           # Subtitle files
-└── downloads/
+assets/ ├── images/ │   ├── optimized/          # Compressed versions │   ├── originals/          # Source files (not served) │   └── thumbnails/         # Small preview images ├── videos/ │   ├── compressed/         # Web-optimized videos │   └── captions/           # Subtitle files └── downloads/
     ├── pdfs/               # Documentation PDFs
     └── archives/           # Downloadable packages
 ```
@@ -1450,20 +1369,13 @@ assets/
 #### Commit Message Standards
 ```bash
 # Use conventional commit format
-docs: add markdown style guide
-docs(api): update endpoint documentation
-fix(docs): correct broken internal links
-feat(docs): add multi-language support
+docs: add markdown style guide docs(api): update endpoint documentation fix(docs): correct broken internal links feat(docs): add multi-language support
 ```
 
 #### Branch Strategy
 ```bash
 # Documentation branches
-main                    # Production documentation
-develop                # Development documentation
-docs/feature-name       # Feature-specific documentation
-docs/translation-es     # Translation branches
-hotfix/docs-typo       # Quick fixes
+main                    # Production documentation develop                # Development documentation docs/feature-name       # Feature-specific documentation docs/translation-es     # Translation branches hotfix/docs-typo       # Quick fixes
 ```
 
 #### Review Checklist
@@ -1538,12 +1450,10 @@ Complex scenario with detailed walkthrough.
 ## Troubleshooting
 
 ### Common Issue 1
-**Problem**: Description of the issue
-**Solution**: How to resolve it
+**Problem**: Description of the issue **Solution**: How to resolve it
 
 ### Common Issue 2
-**Problem**: Another common problem
-**Solution**: Resolution steps
+**Problem**: Another common problem **Solution**: Resolution steps
 
 ## Related Resources
 - [Related Feature 1](./related-feature-1.md)
@@ -1593,8 +1503,7 @@ This Markdown instruction file works in conjunction with:
 #### Path-Based Documentation Configuration
 ```yaml
 # docs-config.yml
-documentation:
-  paths:
+documentation: paths:
     content_creation:
       - planning
       - writing
@@ -1641,8 +1550,7 @@ documentation:
 #### Quality Assurance Configuration
 ```yaml
 # quality-config.yml
-quality_checks:
-  markdown_lint:
+quality_checks: markdown_lint:
     enabled: true
     rules:
       line_length: 100

--- a/.github/instructions/mcp.instructions.md
+++ b/.github/instructions/mcp.instructions.md
@@ -1545,16 +1545,11 @@ The MCP client configuration is available at: `config/mcp/client_config.json`
 ```typescript
 import { PathAwareMCPClient } from './src/mcp/clients/mcp-client';
 
-const client = new PathAwareMCPClient("docker", ["exec", "-i", "mcp-filesystem", "python", "-m", "mcp_servers.filesystem"]);
-await client.connect();
+const client = new PathAwareMCPClient("docker", ["exec", "-i", "mcp-filesystem", "python", "-m", "mcp_servers.filesystem"]); await client.connect();
 
-// List available resources
-const resources = await client.listResources();
-console.log("Available resources:", resources);
+// List available resources const resources = await client.listResources(); console.log("Available resources:", resources);
 
-// Read a specific resource
-const content = await client.readResource(resources[0].uri);
-console.log("Resource content:", content);
+// Read a specific resource const content = await client.readResource(resources[0].uri); console.log("Resource content:", content);
 
 await client.disconnect();
 ```
@@ -1562,8 +1557,7 @@ await client.disconnect();
 ### Python Client
 
 ```python
-import asyncio
-from src.mcp.clients.mcp_client_python import PathAwareMCPClient
+import asyncio from src.mcp.clients.mcp_client_python import PathAwareMCPClient
 
 async def main():
     client = PathAwareMCPClient("docker", ["exec", "-i", "mcp-filesystem", "python", "-m", "mcp_servers.filesystem"])

--- a/.github/instructions/space.instructions.md
+++ b/.github/instructions/space.instructions.md
@@ -335,8 +335,7 @@ Include a new field for paths:
 ```
 
 ### Language-Specific Header Examples
-[Examples updated similarly, adding @paths section, e.g., 
-@paths
+[Examples updated similarly, adding @paths section, e.g., @paths
   - main-processing: Validates input, transforms data, with retry on failure.
   - error-recovery: Logs errors and falls back to default output.
 ]

--- a/.github/workflows/markdown-oneline.yml
+++ b/.github/workflows/markdown-oneline.yml
@@ -1,0 +1,36 @@
+# Seeded by the bamr87 hub (tools/fanout.sh --kit prose). Enforces the house
+# rule "one paragraph per line" in markdown: fails if any tracked *.md has
+# soft-wrapped prose. This is the Liquid-safe surgical unwrapper — it only joins
+# wrapped prose and leaves Liquid/HTML/tables/code/front-matter untouched.
+#
+# Fix locally:  python3 tools/unwrap-prose.py --write
+name: markdown-oneline
+
+on:
+  pull_request:
+    paths: ["**/*.md", "**/*.markdown"]
+  push:
+    branches: [main]
+    paths: ["**/*.md", "**/*.markdown"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: markdown-oneline-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  oneline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Check one paragraph per line
+        run: |
+          python3 tools/unwrap-prose.py --check \
+            --exclude '(^|/)SCHEMA\.md$' --exclude '(^|/)CHANGELOG\.md$' \
+          || { echo "::error::Wrapped markdown prose found. Run: python3 tools/unwrap-prose.py --write"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # 🌱 AI-Seed: The Evolution Engine Repository
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Container First](https://img.shields.io/badge/Container-First-blue.svg)](https://docker.com)
-[![AI Powered](https://img.shields.io/badge/AI-Powered-purple.svg)](https://github.com/features/copilot)
-[![Path Based](https://img.shields.io/badge/Path-Based-green.svg)](#path-philosophy)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Container First](https://img.shields.io/badge/Container-First-blue.svg)](https://docker.com) [![AI Powered](https://img.shields.io/badge/AI-Powered-purple.svg)](https://github.com/features/copilot) [![Path Based](https://img.shields.io/badge/Path-Based-green.svg)](#path-philosophy)
 
 > **"Like water finding its way through terrain, code and information follow paths of least resistance, creating interconnected networks of knowledge and functionality."**
 

--- a/docs/guides/periodic-growth-workflows.md
+++ b/docs/guides/periodic-growth-workflows.md
@@ -19,8 +19,7 @@ Daily (3 AM UTC) ──▶ Weekly (Sunday 6 AM) ──▶ Monthly (1st at 9 AM) 
 ## 📅 Automated Workflow Schedule
 
 ### 🌅 Daily Evolution (3 AM UTC)
-**File**: `.github/workflows/daily-evolution.yml`
-**Purpose**: Routine maintenance and continuous improvement
+**File**: `.github/workflows/daily-evolution.yml` **Purpose**: Routine maintenance and continuous improvement
 
 **What it does**:
 - 🔧 Fixes inconsistencies across files and configurations
@@ -37,8 +36,7 @@ dry_run: [true, false]
 ```
 
 ### 🏥 Weekly Health Check (Sunday 6 AM UTC)
-**File**: `.github/workflows/weekly-health-check.yml`
-**Purpose**: Comprehensive system analysis and preventive maintenance
+**File**: `.github/workflows/weekly-health-check.yml` **Purpose**: Comprehensive system analysis and preventive maintenance
 
 **What it does**:
 - 🏗️ Analyzes repository structure and organization
@@ -54,8 +52,7 @@ dry_run: [true, false]
 - **Testing**: 15% weight - Test coverage ratio
 
 ### 📊 Monthly Evolution Report (1st of month, 9 AM UTC)
-**File**: `.github/workflows/monthly-evolution-report.yml`
-**Purpose**: Progress tracking and strategic planning
+**File**: `.github/workflows/monthly-evolution-report.yml` **Purpose**: Progress tracking and strategic planning
 
 **What it does**:
 - 📈 Analyzes growth patterns and development velocity
@@ -70,8 +67,7 @@ Evolution Score = (Activity × 30%) + (Health × 30%) + (Innovation × 20%) + (D
 ```
 
 ### 🚀 Quarterly Major Evolution (Quarterly, 1st at 12 PM UTC)
-**File**: `.github/workflows/quarterly-major-evolution.yml`
-**Purpose**: Strategic growth with significant enhancements
+**File**: `.github/workflows/quarterly-major-evolution.yml` **Purpose**: Strategic growth with significant enhancements
 
 **What it does**:
 - 🧠 AI-driven strategic planning and focus detection

--- a/tools/unwrap-prose.py
+++ b/tools/unwrap-prose.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+unwrap-prose.py — join soft-wrapped prose lines so each paragraph is one line.
+
+Only body-text paragraphs are unwrapped. Everything structural is left
+byte-for-byte identical: YAML/TOML front matter, fenced & indented code,
+tables (any line containing "|"), lists, blockquotes, ATX & setext headings,
+block-level HTML, Liquid "{% %}" tag lines, reference/footnote definitions,
+thematic breaks, and any paragraph that uses hard line breaks (a line ending
+in two+ spaces or a backslash).
+
+Conservative by design: when a line's role is ambiguous it is treated as a
+boundary and left alone rather than risk corrupting structure. The transform
+is idempotent — running it twice yields the same result as running it once.
+
+Usage:
+  unwrap-prose.py --check [PATHS ...]   # list files that WOULD change; exit 1 if any
+  unwrap-prose.py --diff  [PATHS ...]   # print a unified diff; no writes
+  unwrap-prose.py --write [PATHS ...]   # rewrite files in place
+
+With no PATHS, operates on the current repo's git-tracked *.md / *.markdown
+files (so vendored/ignored/submodule content is excluded automatically).
+"""
+# Vendored verbatim from the bamr87 hub (tools/unwrap-prose.py) into each repo
+# by tools/fanout.sh; it is not the host repo's own source, so it opts out of
+# that repo's linters / type-checkers rather than chase every project's config.
+# ruff: noqa
+# flake8: noqa
+# mypy: ignore-errors
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# --- line classifiers -------------------------------------------------------
+BLANK = re.compile(r"^\s*$")
+FRONT_FENCE = re.compile(r"^(---|\+\+\+)\s*$")          # YAML/TOML front matter delimiter
+FENCE = re.compile(r"^\s{0,3}(`{3,}|~{3,})")            # ``` or ~~~ code fence
+ATX = re.compile(r"^\s{0,3}#{1,6}(\s|$)")               # # Heading
+LIST = re.compile(r"^\s{0,3}([-*+]|\d+[.)])\s")         # -, *, +, 1. list item
+QUOTE = re.compile(r"^\s{0,3}>")                        # > blockquote
+HTML = re.compile(r"^\s{0,3}<")                          # block-level HTML / autolink
+LIQUID = re.compile(r"^\s*\{%")                          # {% if %}, {% for %}, {% include %}
+REF_DEF = re.compile(r"^\s{0,3}\[[^\]]+\]:\s")          # [id]: https://...
+FOOTNOTE = re.compile(r"^\s{0,3}\[\^[^\]]+\]:")         # [^n]: ...
+HR = re.compile(r"^\s{0,3}([-*_])(\s*\1){2,}\s*$")      # ---, ***, ___ thematic break
+INDENT_CODE = re.compile(r"^(\t| {4,})")                # 4-space / tab indented code
+SETEXT = re.compile(r"^\s{0,3}(=+|-+)\s*$")             # === or --- heading underline
+HARD_BREAK = re.compile(r"(\s{2,}|\\)$")                # trailing "  " or "\" -> <br>
+
+
+def starts_atomic(line: str) -> bool:
+    """A line that must never be merged into a prose paragraph."""
+    return bool(
+        ATX.match(line)
+        or LIST.match(line)
+        or QUOTE.match(line)
+        or HTML.match(line)
+        or LIQUID.match(line)
+        or REF_DEF.match(line)
+        or FOOTNOTE.match(line)
+        or HR.match(line)
+        or INDENT_CODE.match(line)
+        or FENCE.match(line)
+        or "|" in line  # any table row (leading-pipe or not) — safe to leave alone
+    )
+
+
+def transform(text: str) -> str:
+    had_final_nl = text.endswith("\n")
+    lines = text.splitlines()
+    out: list[str] = []
+    i, n = 0, len(lines)
+
+    # Front matter: only when the very first line is exactly --- or +++.
+    if n and FRONT_FENCE.match(lines[0]):
+        out.append(lines[0])
+        i = 1
+        while i < n:
+            out.append(lines[i])
+            closed = FRONT_FENCE.match(lines[i])
+            i += 1
+            if closed:
+                break
+
+    while i < n:
+        line = lines[i]
+
+        # Fenced code block: copy verbatim through the matching closing fence.
+        m = FENCE.match(line)
+        if m:
+            ticks = m.group(1)
+            fence_char, fence_len = ticks[0], len(ticks)
+            out.append(line)
+            i += 1
+            while i < n:
+                out.append(lines[i])
+                c = FENCE.match(lines[i])
+                i += 1
+                if c and c.group(1)[0] == fence_char and len(c.group(1)) >= fence_len:
+                    break
+            continue
+
+        if BLANK.match(line) or starts_atomic(line):
+            out.append(line)
+            i += 1
+            continue
+
+        # A prose paragraph: gather its wrapped continuation lines.
+        group = [line]
+        i += 1
+        while i < n:
+            nxt = lines[i]
+            if BLANK.match(nxt) or starts_atomic(nxt) or SETEXT.match(nxt):
+                break
+            if HARD_BREAK.search(group[-1]):          # previous line forces a break
+                break
+            if i + 1 < n and SETEXT.match(lines[i + 1]):  # nxt is a setext heading's text
+                break
+            group.append(nxt)
+            i += 1
+
+        # A paragraph that uses hard breaks keeps its author-chosen line layout.
+        if len(group) == 1 or any(HARD_BREAK.search(g) for g in group):
+            out.extend(group)
+        else:
+            out.append(" ".join(g.strip() for g in group))
+
+    result = "\n".join(out)
+    if had_final_nl:
+        result += "\n"
+    return result
+
+
+# --- driver -----------------------------------------------------------------
+def git_tracked_md() -> list[Path]:
+    try:
+        raw = subprocess.check_output(
+            ["git", "ls-files", "-z", "*.md", "*.markdown"], text=True
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    return [Path(p) for p in raw.split("\0") if p]
+
+
+def iter_paths(paths: list[str]) -> list[Path]:
+    if not paths:
+        return git_tracked_md()
+    found: list[Path] = []
+    for p in paths:
+        pp = Path(p)
+        if pp.is_dir():
+            found += sorted(pp.rglob("*.md")) + sorted(pp.rglob("*.markdown"))
+        else:
+            found.append(pp)
+    return found
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Unwrap soft-wrapped markdown prose.")
+    mode = ap.add_mutually_exclusive_group()
+    mode.add_argument("--check", action="store_true", help="list files that would change; exit 1 if any")
+    mode.add_argument("--diff", action="store_true", help="print a unified diff; no writes")
+    mode.add_argument("--write", action="store_true", help="rewrite files in place")
+    ap.add_argument("--exclude", action="append", metavar="REGEX", default=[],
+                    help="skip paths matching this regex (repeatable)")
+    ap.add_argument("paths", nargs="*", help="files/dirs (default: git-tracked markdown)")
+    args = ap.parse_args()
+
+    excludes = [re.compile(p) for p in args.exclude]
+    changed: list[Path] = []
+    for path in iter_paths(args.paths):
+        if any(rx.search(path.as_posix()) for rx in excludes):
+            continue
+        try:
+            original = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as e:
+            print(f"skip {path}: {e}", file=sys.stderr)
+            continue
+        updated = transform(original)
+        if updated == original:
+            continue
+        changed.append(path)
+        if args.diff:
+            sys.stdout.writelines(
+                difflib.unified_diff(
+                    original.splitlines(keepends=True),
+                    updated.splitlines(keepends=True),
+                    fromfile=str(path),
+                    tofile=str(path),
+                )
+            )
+        elif args.write:
+            path.write_text(updated, encoding="utf-8")
+            print(f"unwrapped {path}")
+        else:  # --check (default)
+            print(path)
+
+    if args.check or not (args.diff or args.write):
+        if changed:
+            print(f"\n{len(changed)} file(s) would change.", file=sys.stderr)
+            return 1
+        print("All markdown prose already unwrapped.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Automated by bamr87 prose-fanout (tools/fanout.sh): unwraps soft-wrapped markdown prose so each paragraph is a single line — Liquid/HTML/tables/code/front-matter left byte-for-byte, and SCHEMA.md/CHANGELOG.md skipped. Also vendors tools/unwrap-prose.py and seeds a markdown-oneline CI check. Additive-only. See bamr87/bamr87.